### PR TITLE
Add shop comparison Flutter prototype

### DIFF
--- a/shop_compare/README.md
+++ b/shop_compare/README.md
@@ -1,0 +1,5 @@
+# Shop Compare
+
+Prototype Flutter app for comparing product prices across multiple shops.
+
+This project is a simplified prototype using placeholder data.

--- a/shop_compare/lib/main.dart
+++ b/shop_compare/lib/main.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'providers/shop_provider.dart';
+import 'screens/search_screen.dart';
+import 'screens/category_screen.dart';
+
+void main() {
+  runApp(const ShopCompareApp());
+}
+
+class ShopCompareApp extends StatelessWidget {
+  const ShopCompareApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (_) => ShopProvider(),
+      child: MaterialApp(
+        title: 'Shop Compare',
+        theme: ThemeData(primarySwatch: Colors.blue),
+        home: const _Home(),
+      ),
+    );
+  }
+}
+
+class _Home extends StatefulWidget {
+  const _Home({Key? key}) : super(key: key);
+
+  @override
+  State<_Home> createState() => _HomeState();
+}
+
+class _HomeState extends State<_Home> {
+  int _index = 0;
+  final _pages = [const SearchScreen(), const CategoryScreen()];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _pages[_index],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _index,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.search), label: '検索'),
+          BottomNavigationBarItem(icon: Icon(Icons.list), label: 'カテゴリ'),
+        ],
+        onTap: (i) => setState(() => _index = i),
+      ),
+    );
+  }
+}

--- a/shop_compare/lib/models/product.dart
+++ b/shop_compare/lib/models/product.dart
@@ -1,0 +1,15 @@
+class Product {
+  final String shopName;
+  final String name;
+  final int price;
+  final int shipping;
+  final String eta;
+
+  Product({
+    required this.shopName,
+    required this.name,
+    required this.price,
+    required this.shipping,
+    required this.eta,
+  });
+}

--- a/shop_compare/lib/providers/shop_provider.dart
+++ b/shop_compare/lib/providers/shop_provider.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import '../models/product.dart';
+
+class ShopProvider with ChangeNotifier {
+  List<Product> _results = [];
+  List<Product> get results => _results;
+
+  Future<void> search(String query) async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    _results = _mockSearch(query);
+    notifyListeners();
+  }
+
+  List<Product> _mockSearch(String query) {
+    // Placeholder search returning sample data.
+    return [
+      Product(shopName: 'Amazon', name: '$query - Sample A', price: 1000, shipping: 0, eta: '2 days'),
+      Product(shopName: 'Rakuten', name: '$query - Sample B', price: 1100, shipping: 100, eta: '3 days'),
+      Product(shopName: 'Yahoo', name: '$query - Sample C', price: 1050, shipping: 50, eta: '4 days'),
+      Product(shopName: 'Yodobashi', name: '$query - Sample D', price: 980, shipping: 0, eta: '1 day'),
+    ];
+  }
+
+  Future<List<Product>> trending(String category) async {
+    await Future.delayed(const Duration(milliseconds: 300));
+    return [
+      Product(shopName: 'Amazon', name: '$category Hit A', price: 2000, shipping: 0, eta: '2 days'),
+      Product(shopName: 'Rakuten', name: '$category Hit B', price: 2100, shipping: 100, eta: '3 days'),
+    ];
+  }
+}

--- a/shop_compare/lib/screens/category_screen.dart
+++ b/shop_compare/lib/screens/category_screen.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'trending_screen.dart';
+
+class CategoryScreen extends StatelessWidget {
+  const CategoryScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final categories = ['家電', '本', 'ゲーム', 'ファッション'];
+    return Scaffold(
+      appBar: AppBar(title: const Text('カテゴリ')),
+      body: ListView.builder(
+        itemCount: categories.length,
+        itemBuilder: (context, index) {
+          final c = categories[index];
+          return ListTile(
+            title: Text(c),
+            trailing: const Icon(Icons.chevron_right),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => TrendingScreen(category: c),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/shop_compare/lib/screens/result_screen.dart
+++ b/shop_compare/lib/screens/result_screen.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/shop_provider.dart';
+
+class ResultScreen extends StatelessWidget {
+  const ResultScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final results = context.watch<ShopProvider>().results;
+    return Scaffold(
+      appBar: AppBar(title: const Text('検索結果')),
+      body: ListView.builder(
+        itemCount: results.length,
+        itemBuilder: (context, index) {
+          final p = results[index];
+          return Card(
+            margin: const EdgeInsets.all(8),
+            child: ListTile(
+              title: Text('${p.shopName}: ${p.name}'),
+              subtitle: Text('¥${p.price} (送料: ¥${p.shipping})\n到着予定: ${p.eta}'),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/shop_compare/lib/screens/search_screen.dart
+++ b/shop_compare/lib/screens/search_screen.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/shop_provider.dart';
+import 'result_screen.dart';
+
+class SearchScreen extends StatefulWidget {
+  const SearchScreen({Key? key}) : super(key: key);
+
+  @override
+  State<SearchScreen> createState() => _SearchScreenState();
+}
+
+class _SearchScreenState extends State<SearchScreen> {
+  final _controller = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('商品検索')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: _controller,
+              decoration: const InputDecoration(
+                labelText: '商品名',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () {
+                context.read<ShopProvider>().search(_controller.text).then((_) {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const ResultScreen(),
+                    ),
+                  );
+                });
+              },
+              child: const Text('検索'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/shop_compare/lib/screens/trending_screen.dart
+++ b/shop_compare/lib/screens/trending_screen.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/shop_provider.dart';
+
+class TrendingScreen extends StatelessWidget {
+  final String category;
+  const TrendingScreen({Key? key, required this.category}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('$category の売れ筋')),
+      body: FutureBuilder(
+        future: context.read<ShopProvider>().trending(category),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final items = snapshot.data as List;
+          return ListView.builder(
+            itemCount: items.length,
+            itemBuilder: (context, index) {
+              final p = items[index];
+              return Card(
+                margin: const EdgeInsets.all(8),
+                child: ListTile(
+                  title: Text('${p.shopName}: ${p.name}'),
+                  subtitle: Text('¥${p.price} (送料: ¥${p.shipping})\n到着予定: ${p.eta}'),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/shop_compare/pubspec.yaml
+++ b/shop_compare/pubspec.yaml
@@ -1,0 +1,21 @@
+name: shop_compare
+description: A sample shopping comparison Flutter app
+publish_to: 'none'
+version: 0.1.0+1
+
+environment:
+  sdk: '>=3.0.0 <4.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  provider: ^6.0.5
+
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true

--- a/shop_compare/test/widget_test.dart
+++ b/shop_compare/test/widget_test.dart
@@ -1,0 +1,1 @@
+void main() {}


### PR DESCRIPTION
## Summary
- add Shop Compare prototype with provider-based state management
- implement search, results, categories, and trending screens
- supply placeholder data via ShopProvider
- document project purpose in README

## Testing
- `dart` was unavailable in the environment, so no tests were run


------
https://chatgpt.com/codex/tasks/task_e_68411d19ddc0832a9b9349687825bd19