### PR TITLE
Add search screen widget test

### DIFF
--- a/shop_compare/test/widget_test.dart
+++ b/shop_compare/test/widget_test.dart
@@ -1,1 +1,36 @@
-void main() {}
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import 'package:shop_compare/screens/search_screen.dart';
+import 'package:shop_compare/providers/shop_provider.dart';
+
+class FakeShopProvider extends ShopProvider {
+  bool called = false;
+
+  @override
+  Future<void> search(String query) async {
+    called = true;
+  }
+}
+
+void main() {
+  testWidgets('searching navigates to result screen', (WidgetTester tester) async {
+    final provider = FakeShopProvider();
+    await tester.pumpWidget(
+      ChangeNotifierProvider<ShopProvider>.value(
+        value: provider,
+        child: const MaterialApp(
+          home: SearchScreen(),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'test product');
+    await tester.tap(find.text('検索'));
+    await tester.pumpAndSettle();
+
+    expect(provider.called, isTrue);
+    expect(find.text('検索結果'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add functional widget test for search screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841250ec0dc832a8ecf5f429dfbdaf3