### PR TITLE
Implement search and product UI mockups

### DIFF
--- a/shop_compare/lib/providers/shop_provider.dart
+++ b/shop_compare/lib/providers/shop_provider.dart
@@ -14,10 +14,10 @@ class ShopProvider with ChangeNotifier {
   List<Product> _mockSearch(String query) {
     // Placeholder search returning sample data.
     return [
-      Product(shopName: 'Amazon', name: '$query - Sample A', price: 1000, shipping: 0, eta: '2 days'),
-      Product(shopName: 'Rakuten', name: '$query - Sample B', price: 1100, shipping: 100, eta: '3 days'),
-      Product(shopName: 'Yahoo', name: '$query - Sample C', price: 1050, shipping: 50, eta: '4 days'),
-      Product(shopName: 'Yodobashi', name: '$query - Sample D', price: 980, shipping: 0, eta: '1 day'),
+      Product(shopName: 'Amazon', name: '$query 商品1', price: 1000, shipping: 0, eta: '2 days'),
+      Product(shopName: '楽天', name: '$query 商品1', price: 1100, shipping: 100, eta: '3 days'),
+      Product(shopName: 'Yahoo', name: '$query 商品2', price: 1050, shipping: 50, eta: '4 days'),
+      Product(shopName: 'ヨドバシ', name: '$query 商品2', price: 980, shipping: 0, eta: '1 day'),
     ];
   }
 

--- a/shop_compare/lib/screens/detail_search_screen.dart
+++ b/shop_compare/lib/screens/detail_search_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class DetailSearchScreen extends StatelessWidget {
+  const DetailSearchScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('詳細検索')),
+      body: const Center(
+        child: Text('詳細検索画面は未実装です'),
+      ),
+    );
+  }
+}

--- a/shop_compare/lib/screens/product_screen.dart
+++ b/shop_compare/lib/screens/product_screen.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../models/product.dart';
+
+class ProductScreen extends StatelessWidget {
+  final String productName;
+  final List<Product> offers;
+  const ProductScreen({Key? key, required this.productName, required this.offers}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(productName)),
+      body: Column(
+        children: [
+          GestureDetector(
+            onTap: () {
+              showDialog(
+                context: context,
+                builder: (_) => const Dialog(
+                  child: SizedBox(
+                    width: 200,
+                    height: 200,
+                    child: Icon(Icons.image, size: 150),
+                  ),
+                ),
+              );
+            },
+            child: const Padding(
+              padding: EdgeInsets.all(16),
+              child: Icon(Icons.image, size: 100),
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: offers.length,
+              itemBuilder: (context, index) {
+                final o = offers[index];
+                return ListTile(
+                  leading: const Icon(Icons.store),
+                  title: Text(o.shopName),
+                  subtitle: Text('価格: ¥${o.price} 送料: ¥${o.shipping} 配送: ${o.eta}'),
+                  onTap: () async {
+                    final uri = Uri.parse('https://example.com');
+                    if (await canLaunchUrl(uri)) {
+                      await launchUrl(uri, mode: LaunchMode.externalApplication);
+                    }
+                  },
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/shop_compare/lib/screens/search_screen.dart
+++ b/shop_compare/lib/screens/search_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import '../providers/shop_provider.dart';
-import 'result_screen.dart';
+import '../models/product.dart';
+import 'detail_search_screen.dart';
+import 'product_screen.dart';
 
 class SearchScreen extends StatefulWidget {
   const SearchScreen({Key? key}) : super(key: key);
@@ -10,41 +12,164 @@ class SearchScreen extends StatefulWidget {
   State<SearchScreen> createState() => _SearchScreenState();
 }
 
+class _AggregatedProduct {
+  final String name;
+  final List<Product> offers;
+  _AggregatedProduct({required this.name, required this.offers});
+
+  int get minPrice => offers.map((p) => p.price).reduce((a, b) => a < b ? a : b);
+  int get maxPrice => offers.map((p) => p.price).reduce((a, b) => a > b ? a : b);
+  List<String> get shopNames => offers.map((p) => p.shopName).toList();
+}
+
 class _SearchScreenState extends State<SearchScreen> {
   final _controller = TextEditingController();
+  final _minController = TextEditingController();
+  final _maxController = TextEditingController();
+  String _sort = 'none';
 
   @override
   Widget build(BuildContext context) {
+    final results = context.watch<ShopProvider>().results;
+    final aggregated = _aggregate(results);
     return Scaffold(
       appBar: AppBar(title: const Text('商品検索')),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: _buildSearchArea(context),
+          ),
+          Expanded(
+            child: aggregated.isEmpty
+                ? const Center(child: Text('検索結果がありません'))
+                : ListView.builder(
+                    itemCount: aggregated.length,
+                    itemBuilder: (context, index) {
+                      final item = aggregated[index];
+                      return GestureDetector(
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => ProductScreen(
+                                productName: item.name,
+                                offers: item.offers,
+                              ),
+                            ),
+                          );
+                        },
+                        child: Card(
+                          margin: const EdgeInsets.all(8),
+                          child: Row(
+                            children: [
+                              const SizedBox(
+                                width: 80,
+                                height: 80,
+                                child: Icon(Icons.image, size: 50),
+                              ),
+                              Expanded(
+                                child: ListTile(
+                                  title: Text(item.name),
+                                  subtitle: Text(
+                                      '取扱: ${item.shopNames.join(', ')}\n最安値: ¥${item.minPrice}  最高値: ¥${item.maxPrice}'),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchArea(BuildContext context) {
+    return Column(
+      children: [
+        TextField(
+          controller: _controller,
+          decoration: const InputDecoration(
+            labelText: '検索ワード',
+            border: OutlineInputBorder(),
+          ),
+        ),
+        const SizedBox(height: 8),
+        Row(
           children: [
-            TextField(
-              controller: _controller,
-              decoration: const InputDecoration(
-                labelText: '商品名',
-                border: OutlineInputBorder(),
+            Expanded(
+              child: DropdownButton<String>(
+                value: _sort,
+                isExpanded: true,
+                items: const [
+                  DropdownMenuItem(value: 'none', child: Text('ソートなし')),
+                  DropdownMenuItem(value: 'asc', child: Text('価格が安い順')),
+                  DropdownMenuItem(value: 'desc', child: Text('価格が高い順')),
+                ],
+                onChanged: (v) => setState(() => _sort = v ?? 'none'),
               ),
             ),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: () {
-                context.read<ShopProvider>().search(_controller.text).then((_) {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (_) => const ResultScreen(),
-                    ),
-                  );
-                });
-              },
-              child: const Text('検索'),
+            const SizedBox(width: 8),
+            SizedBox(
+              width: 80,
+              child: TextField(
+                controller: _minController,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(labelText: '最小'),
+              ),
+            ),
+            const SizedBox(width: 8),
+            SizedBox(
+              width: 80,
+              child: TextField(
+                controller: _maxController,
+                keyboardType: TextInputType.number,
+                decoration: const InputDecoration(labelText: '最大'),
+              ),
             ),
           ],
         ),
-      ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            ElevatedButton(
+              onPressed: () {
+                context.read<ShopProvider>().search(_controller.text);
+              },
+              child: const Text('検索'),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const DetailSearchScreen()),
+                );
+              },
+              child: const Text('詳細検索'),
+            ),
+          ],
+        ),
+      ],
     );
+  }
+
+  List<_AggregatedProduct> _aggregate(List<Product> list) {
+    final map = <String, List<Product>>{};
+    for (var p in list) {
+      map.putIfAbsent(p.name, () => []).add(p);
+    }
+    final items = map.entries
+        .map((e) => _AggregatedProduct(name: e.key, offers: e.value))
+        .toList();
+    if (_sort == 'asc') {
+      items.sort((a, b) => a.minPrice.compareTo(b.minPrice));
+    } else if (_sort == 'desc') {
+      items.sort((a, b) => b.maxPrice.compareTo(a.maxPrice));
+    }
+    return items;
   }
 }

--- a/shop_compare/pubspec.yaml
+++ b/shop_compare/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   provider: ^6.0.5
+  url_launcher: ^6.1.10
 
   cupertino_icons: ^1.0.2
 


### PR DESCRIPTION
## Summary
- mock up search UI with sort, price range and result cards
- add detail search placeholder screen
- create product screen to show offers per shop
- sample data now groups products by name
- add url_launcher dependency

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841358cca98832a8556c91636dc481c