### PR TITLE
Integrate Yahoo Shopping search

### DIFF
--- a/shop_compare/README.md
+++ b/shop_compare/README.md
@@ -2,4 +2,10 @@
 
 Prototype Flutter app for comparing product prices across multiple shops.
 
-This project is a simplified prototype using placeholder data.
+The search feature now queries Yahoo Shopping's public API using a built in
+client ID. Results from Amazon and Rakuten remain mocked.
+
+To fetch dependencies run:
+```
+flutter pub get
+```

--- a/shop_compare/lib/providers/shop_provider.dart
+++ b/shop_compare/lib/providers/shop_provider.dart
@@ -1,14 +1,48 @@
+import 'dart:convert';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
 import '../models/product.dart';
 
 class ShopProvider with ChangeNotifier {
   List<Product> _results = [];
   List<Product> get results => _results;
 
+  static const _yahooClientId =
+      'dj00aiZpPXJkMXJNYjZLTEQyMyZzPWNvbnN1bWVyc2VjcmV0Jng9NzE-';
+
   Future<void> search(String query) async {
-    await Future.delayed(const Duration(milliseconds: 300));
-    _results = _mockSearch(query);
+    final yahoo = await _searchYahoo(query);
+    final others = _mockSearch(query);
+    _results = [...yahoo, ...others];
     notifyListeners();
+  }
+
+  Future<List<Product>> _searchYahoo(String query) async {
+    final uri = Uri.https('shopping.yahooapis.jp',
+        '/ShoppingWebService/V3/itemSearch', {
+      'appid': _yahooClientId,
+      'query': query,
+      'hits': '10',
+    });
+    try {
+      final res = await http.get(uri);
+      if (res.statusCode == 200) {
+        final data = jsonDecode(res.body) as Map<String, dynamic>;
+        final hits = data['hits'] as List<dynamic>;
+        return hits.map((e) {
+          return Product(
+            shopName: 'Yahoo',
+            name: e['name'] ?? '',
+            price: (e['price'] as num?)?.toInt() ?? 0,
+            shipping: 0,
+            eta: '',
+          );
+        }).toList();
+      }
+    } catch (_) {
+      // ignore errors
+    }
+    return [];
   }
 
   List<Product> _mockSearch(String query) {

--- a/shop_compare/pubspec.yaml
+++ b/shop_compare/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
   provider: ^6.0.5
   url_launcher: ^6.1.10
+  http: ^0.13.6
 
   cupertino_icons: ^1.0.2
 


### PR DESCRIPTION
## Summary
- connect search to Yahoo Shopping API using built-in Client ID
- add http dependency
- document Yahoo integration in README

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413d66e1dc832aab51b0e18a19699e