### PR TITLE
Add item URLs from Yahoo results

### DIFF
--- a/shop_compare/lib/models/product.dart
+++ b/shop_compare/lib/models/product.dart
@@ -5,6 +5,7 @@ class Product {
   final int shipping;
   final String eta;
   final String imageUrl;
+  final String itemUrl;
 
   Product({
     required this.shopName,
@@ -13,5 +14,6 @@ class Product {
     required this.shipping,
     required this.eta,
     required this.imageUrl,
+    required this.itemUrl,
   });
 }

--- a/shop_compare/lib/providers/shop_provider.dart
+++ b/shop_compare/lib/providers/shop_provider.dart
@@ -49,17 +49,19 @@ class ShopProvider with ChangeNotifier {
         final data = jsonDecode(res.body) as Map<String, dynamic>;
         final hits = data['hits'] as List<dynamic>;
         final futures = hits.map<Future<Product>>((e) async {
-          String url = e['image']?['small'] ?? '';
-          if (url.isEmpty && e['code'] != null) {
-            url = await _fetchImageFromYahoo(e['code']);
+          String image = e['image']?['small'] ?? '';
+          if (image.isEmpty && e['code'] != null) {
+            image = await _fetchImageFromYahoo(e['code']);
           }
+          final itemUrl = e['url'] ?? '';
           return Product(
             shopName: 'Yahoo',
             name: e['name'] ?? '',
             price: (e['price'] as num?)?.toInt() ?? 0,
             shipping: 0,
             eta: '',
-            imageUrl: url,
+            imageUrl: image,
+            itemUrl: itemUrl,
           );
         }).toList();
         return Future.wait(futures);
@@ -73,17 +75,17 @@ class ShopProvider with ChangeNotifier {
   List<Product> _mockSearch(String query) {
     // Placeholder search returning sample data.
     return [
-      Product(shopName: 'Amazon', name: '$query 商品1', price: 1000, shipping: 0, eta: '2 days', imageUrl: ''),
-      Product(shopName: '楽天', name: '$query 商品1', price: 1100, shipping: 100, eta: '3 days', imageUrl: ''),
-      Product(shopName: 'Yahoo', name: '$query 商品2', price: 1050, shipping: 50, eta: '4 days', imageUrl: ''),
+      Product(shopName: 'Amazon', name: '$query 商品1', price: 1000, shipping: 0, eta: '2 days', imageUrl: '', itemUrl: ''),
+      Product(shopName: '楽天', name: '$query 商品1', price: 1100, shipping: 100, eta: '3 days', imageUrl: '', itemUrl: ''),
+      Product(shopName: 'Yahoo', name: '$query 商品2', price: 1050, shipping: 50, eta: '4 days', imageUrl: '', itemUrl: ''),
     ];
   }
 
   Future<List<Product>> trending(String category) async {
     await Future.delayed(const Duration(milliseconds: 300));
     return [
-      Product(shopName: 'Amazon', name: '$category Hit A', price: 2000, shipping: 0, eta: '2 days', imageUrl: ''),
-      Product(shopName: 'Rakuten', name: '$category Hit B', price: 2100, shipping: 100, eta: '3 days', imageUrl: ''),
+      Product(shopName: 'Amazon', name: '$category Hit A', price: 2000, shipping: 0, eta: '2 days', imageUrl: '', itemUrl: ''),
+      Product(shopName: 'Rakuten', name: '$category Hit B', price: 2100, shipping: 100, eta: '3 days', imageUrl: '', itemUrl: ''),
     ];
   }
 }

--- a/shop_compare/lib/screens/product_screen.dart
+++ b/shop_compare/lib/screens/product_screen.dart
@@ -46,7 +46,8 @@ class ProductScreen extends StatelessWidget {
                   title: Text(o.shopName),
                   subtitle: Text('価格: ¥${o.price} 送料: ¥${o.shipping} 配送: ${o.eta}'),
                   onTap: () async {
-                    final uri = Uri.parse('https://example.com');
+                    if (o.itemUrl.isEmpty) return;
+                    final uri = Uri.parse(o.itemUrl);
                     if (await canLaunchUrl(uri)) {
                       await launchUrl(uri, mode: LaunchMode.externalApplication);
                     }


### PR DESCRIPTION
## Summary
- support itemUrl on `Product`
- parse `url` from Yahoo API search results
- open item pages from `ProductScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684151c8a228832ab13dbb6ce26adacf