### PR TITLE
Add shipping name and delivery day

### DIFF
--- a/shop_compare/lib/models/product.dart
+++ b/shop_compare/lib/models/product.dart
@@ -3,6 +3,8 @@ class Product {
   final String name;
   final int price;
   final int shipping;
+  final String shippingName;
+  final int deliveryDay;
   final String eta;
   final String imageUrl;
   final String itemUrl;
@@ -12,6 +14,8 @@ class Product {
     required this.name,
     required this.price,
     required this.shipping,
+    required this.shippingName,
+    required this.deliveryDay,
     required this.eta,
     required this.imageUrl,
     required this.itemUrl,

--- a/shop_compare/lib/providers/shop_provider.dart
+++ b/shop_compare/lib/providers/shop_provider.dart
@@ -54,11 +54,15 @@ class ShopProvider with ChangeNotifier {
             image = await _fetchImageFromYahoo(e['code']);
           }
           final itemUrl = e['url'] ?? '';
+          final shippingName = e['shipping']?['name'] ?? '';
+          final deliveryDay = (e['delivery']?['day'] as num?)?.toInt() ?? 0;
           return Product(
             shopName: 'Yahoo',
             name: e['name'] ?? '',
             price: (e['price'] as num?)?.toInt() ?? 0,
             shipping: 0,
+            shippingName: shippingName,
+            deliveryDay: deliveryDay,
             eta: '',
             imageUrl: image,
             itemUrl: itemUrl,
@@ -75,17 +79,62 @@ class ShopProvider with ChangeNotifier {
   List<Product> _mockSearch(String query) {
     // Placeholder search returning sample data.
     return [
-      Product(shopName: 'Amazon', name: '$query 商品1', price: 1000, shipping: 0, eta: '2 days', imageUrl: '', itemUrl: ''),
-      Product(shopName: '楽天', name: '$query 商品1', price: 1100, shipping: 100, eta: '3 days', imageUrl: '', itemUrl: ''),
-      Product(shopName: 'Yahoo', name: '$query 商品2', price: 1050, shipping: 50, eta: '4 days', imageUrl: '', itemUrl: ''),
+      Product(
+          shopName: 'Amazon',
+          name: '$query 商品1',
+          price: 1000,
+          shipping: 0,
+          shippingName: '送料無料',
+          deliveryDay: 2,
+          eta: '2 days',
+          imageUrl: '',
+          itemUrl: ''),
+      Product(
+          shopName: '楽天',
+          name: '$query 商品1',
+          price: 1100,
+          shipping: 100,
+          shippingName: '宅配便',
+          deliveryDay: 3,
+          eta: '3 days',
+          imageUrl: '',
+          itemUrl: ''),
+      Product(
+          shopName: 'Yahoo',
+          name: '$query 商品2',
+          price: 1050,
+          shipping: 50,
+          shippingName: '宅配便',
+          deliveryDay: 4,
+          eta: '4 days',
+          imageUrl: '',
+          itemUrl: ''),
     ];
   }
 
   Future<List<Product>> trending(String category) async {
     await Future.delayed(const Duration(milliseconds: 300));
     return [
-      Product(shopName: 'Amazon', name: '$category Hit A', price: 2000, shipping: 0, eta: '2 days', imageUrl: '', itemUrl: ''),
-      Product(shopName: 'Rakuten', name: '$category Hit B', price: 2100, shipping: 100, eta: '3 days', imageUrl: '', itemUrl: ''),
+      Product(
+          shopName: 'Amazon',
+          name: '$category Hit A',
+          price: 2000,
+          shipping: 0,
+          shippingName: '送料無料',
+          deliveryDay: 2,
+          eta: '2 days',
+          imageUrl: '',
+          itemUrl: ''),
+      Product(
+          shopName: 'Rakuten',
+          name: '$category Hit B',
+          price: 2100,
+          shipping: 100,
+          shippingName: '宅配便',
+          deliveryDay: 3,
+          eta: '3 days',
+          imageUrl: '',
+          itemUrl: ''),
     ];
   }
 }

--- a/shop_compare/lib/screens/product_screen.dart
+++ b/shop_compare/lib/screens/product_screen.dart
@@ -44,7 +44,8 @@ class ProductScreen extends StatelessWidget {
                 return ListTile(
                   leading: const Icon(Icons.store),
                   title: Text(o.shopName),
-                  subtitle: Text('価格: ¥${o.price} 送料: ¥${o.shipping} 配送: ${o.eta}'),
+                  subtitle: Text(
+                      '価格: ¥${o.price} 送料: ¥${o.shipping} ${o.shippingName} 配送: ${o.eta} (${o.deliveryDay}日)'),
                   onTap: () async {
                     if (o.itemUrl.isEmpty) return;
                     final uri = Uri.parse(o.itemUrl);

--- a/shop_compare/lib/screens/result_screen.dart
+++ b/shop_compare/lib/screens/result_screen.dart
@@ -18,7 +18,8 @@ class ResultScreen extends StatelessWidget {
             margin: const EdgeInsets.all(8),
             child: ListTile(
               title: Text('${p.shopName}: ${p.name}'),
-              subtitle: Text('¥${p.price} (送料: ¥${p.shipping})\n到着予定: ${p.eta}'),
+              subtitle: Text(
+                  '¥${p.price} (送料: ¥${p.shipping} ${p.shippingName})\n到着予定: ${p.eta} (${p.deliveryDay}日)'),
             ),
           );
         },

--- a/shop_compare/lib/screens/search_screen.dart
+++ b/shop_compare/lib/screens/search_screen.dart
@@ -21,6 +21,17 @@ class _AggregatedProduct {
   int get maxPrice => offers.map((p) => p.price).reduce((a, b) => a > b ? a : b);
   List<String> get shopNames => offers.map((p) => p.shopName).toList();
   String get imageUrl => offers.isNotEmpty ? offers.first.imageUrl : '';
+  String get shippingName {
+    if (offers.isEmpty) return '';
+    final cheapest = offers.reduce((a, b) => a.price <= b.price ? a : b);
+    return cheapest.shippingName;
+  }
+
+  int get deliveryDay {
+    if (offers.isEmpty) return 0;
+    final cheapest = offers.reduce((a, b) => a.price <= b.price ? a : b);
+    return cheapest.deliveryDay;
+  }
 }
 
 class _SearchScreenState extends State<SearchScreen> {
@@ -75,7 +86,7 @@ class _SearchScreenState extends State<SearchScreen> {
                                 child: ListTile(
                                   title: Text(item.name),
                                   subtitle: Text(
-                                      '取扱: ${item.shopNames.join(', ')}\n最安値: ¥${item.minPrice}  最高値: ¥${item.maxPrice}'),
+                                      '取扱: ${item.shopNames.join(', ')}\n最安値: ¥${item.minPrice}  最高値: ¥${item.maxPrice}\n配送: ${item.shippingName} (${item.deliveryDay}日)'),
                                 ),
                               ),
                             ],

--- a/shop_compare/lib/screens/trending_screen.dart
+++ b/shop_compare/lib/screens/trending_screen.dart
@@ -25,7 +25,8 @@ class TrendingScreen extends StatelessWidget {
                 margin: const EdgeInsets.all(8),
                 child: ListTile(
                   title: Text('${p.shopName}: ${p.name}'),
-                  subtitle: Text('¥${p.price} (送料: ¥${p.shipping})\n到着予定: ${p.eta}'),
+                  subtitle: Text(
+                      '¥${p.price} (送料: ¥${p.shipping} ${p.shippingName})\n到着予定: ${p.eta} (${p.deliveryDay}日)'),
                 ),
               );
             },


### PR DESCRIPTION
## Summary
- parse shipping name and delivery day from Yahoo search results
- extend `Product` model to hold shipping name and delivery day
- include this info in mock data and trending results
- show shipping name and delivery day on search result cards and detail screens

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68415ac39688832a84ecd78236858cc0