### PR TITLE
Add Rakuten search and provider test

### DIFF
--- a/shop_compare/README.md
+++ b/shop_compare/README.md
@@ -2,8 +2,10 @@
 
 Prototype Flutter app for comparing product prices across multiple shops.
 
-The search feature now queries Yahoo Shopping's public API using a built in
-client ID. Results from Amazon and Rakuten remain mocked.
+The search feature now queries both Yahoo Shopping and Rakuten Ichiba APIs
+using sample credentials included in the source. For production builds it is
+recommended to provide `YAHOO_CLIENT_ID`, `RAKUTEN_APP_ID` and
+`RAKUTEN_AFFILIATE_ID` environment variables and inject them at build time.
 
 To fetch dependencies run:
 ```

--- a/shop_compare/test/provider_search_test.dart
+++ b/shop_compare/test/provider_search_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shop_compare/models/product.dart';
+import 'package:shop_compare/providers/shop_provider.dart';
+
+void main() {
+  test('search aggregates results from Yahoo and Rakuten', () async {
+    final yahooProducts = [
+      Product(
+        shopName: 'Yahoo',
+        name: 'Y',
+        price: 1,
+        shipping: 0,
+        shippingName: '',
+        deliveryDay: 0,
+        eta: '',
+        imageUrls: const [],
+        itemUrl: '',
+      )
+    ];
+    final rakutenProducts = [
+      Product(
+        shopName: 'Rakuten',
+        name: 'R',
+        price: 2,
+        shipping: 0,
+        shippingName: '',
+        deliveryDay: 0,
+        eta: '',
+        imageUrls: const [],
+        itemUrl: '',
+      )
+    ];
+
+    final provider = TestShopProvider(
+      yahooReturn: yahooProducts,
+      rakutenReturn: rakutenProducts,
+    );
+
+    await provider.search('test');
+
+    expect(provider.yahooCalled, isTrue);
+    expect(provider.rakutenCalled, isTrue);
+    expect(provider.results, equals([...yahooProducts, ...rakutenProducts]));
+  });
+}


### PR DESCRIPTION
## Summary
- connect to Rakuten Ichiba API in `ShopProvider`
- call both Yahoo and Rakuten search providers together
- provide helper `TestShopProvider` for unit testing
- add unit test verifying both searches are invoked
- document Rakuten API keys and env variable usage

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416cbd0330832a8a8812be7810ab46