### PR TITLE
Implement product merging for search

### DIFF
--- a/shop_compare/lib/models/product.dart
+++ b/shop_compare/lib/models/product.dart
@@ -8,6 +8,7 @@ class Product {
   final String eta;
   final List<String> imageUrls;
   final String itemUrl;
+  final String jan;
 
   Product({
     required this.shopName,
@@ -19,6 +20,7 @@ class Product {
     required this.eta,
     required this.imageUrls,
     required this.itemUrl,
+    this.jan = '',
   });
 
   String get imageUrl => imageUrls.isNotEmpty ? imageUrls.first : '';

--- a/shop_compare/lib/providers/shop_provider.dart
+++ b/shop_compare/lib/providers/shop_provider.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import '../models/product.dart';
+import '../utils/product_merger.dart';
 
 class ShopProvider with ChangeNotifier {
   List<Product> _results = [];
@@ -52,7 +53,7 @@ class ShopProvider with ChangeNotifier {
     final yahoo = results[0] as List<Product>;
     final rakuten = results[1] as List<Product>;
     final others = _mockSearch(query);
-    _results = [...yahoo, ...rakuten, ...others];
+    _results = mergeProductLists([yahoo, rakuten, others]);
     notifyListeners();
   }
 
@@ -83,6 +84,7 @@ class ShopProvider with ChangeNotifier {
           final itemUrl = e['url'] ?? '';
           final shippingName = e['shipping']?['name'] ?? '';
           final deliveryDay = (e['delivery']?['day'] as num?)?.toInt() ?? 0;
+          final jan = e['janCode'] ?? '';
           return Product(
             shopName: 'Yahoo',
             name: e['name'] ?? '',
@@ -93,6 +95,7 @@ class ShopProvider with ChangeNotifier {
             eta: '',
             imageUrls: images,
             itemUrl: itemUrl,
+            jan: jan,
           );
         }).toList();
         return Future.wait(futures);
@@ -129,6 +132,7 @@ class ShopProvider with ChangeNotifier {
             if (url is String) imageUrls.add(url);
           }
           final itemUrl = item['affiliateUrl'] ?? item['itemUrl'] ?? '';
+          final jan = item['jan'] ?? '';
           return Product(
             shopName: 'Rakuten',
             name: item['itemName'] ?? '',
@@ -139,6 +143,7 @@ class ShopProvider with ChangeNotifier {
             eta: '',
             imageUrls: imageUrls,
             itemUrl: itemUrl,
+            jan: jan,
           );
         }).whereType<Product>().toList();
       }

--- a/shop_compare/lib/utils/product_merger.dart
+++ b/shop_compare/lib/utils/product_merger.dart
@@ -1,0 +1,24 @@
+import '../models/product.dart';
+import 'string_utils.dart';
+
+bool _sameProduct(Product a, Product b) {
+  if (a.jan.isNotEmpty && b.jan.isNotEmpty && a.jan == b.jan) {
+    return true;
+  }
+  return isSimilar(a.name, b.name);
+}
+
+List<Product> mergeProductLists(List<List<Product>> lists) {
+  final merged = <Product>[];
+  for (final list in lists) {
+    for (final p in list) {
+      final index = merged.indexWhere((m) => _sameProduct(p, m));
+      if (index == -1) {
+        merged.add(p);
+      } else {
+        // keep existing (earlier list takes precedence)
+      }
+    }
+  }
+  return merged;
+}

--- a/shop_compare/lib/utils/string_utils.dart
+++ b/shop_compare/lib/utils/string_utils.dart
@@ -1,0 +1,60 @@
+String _toKatakana(String input) {
+  final buffer = StringBuffer();
+  for (final code in input.runes) {
+    if (code >= 0x3041 && code <= 0x3096) {
+      buffer.writeCharCode(code + 0x60);
+    } else {
+      buffer.writeCharCode(code);
+    }
+  }
+  return buffer.toString();
+}
+
+String normalizeText(String input) {
+  var s = input.toLowerCase();
+  s = s.replaceAll(RegExp(r'\s+'), '');
+  s = _toKatakana(s);
+  return s;
+}
+
+int _levenshtein(String s, String t) {
+  if (s == t) return 0;
+  if (s.isEmpty) return t.length;
+  if (t.isEmpty) return s.length;
+
+  final v0 = List<int>.generate(t.length + 1, (i) => i);
+  final v1 = List<int>.filled(t.length + 1, 0);
+
+  for (var i = 0; i < s.length; i++) {
+    v1[0] = i + 1;
+    for (var j = 0; j < t.length; j++) {
+      final cost = s[i] == t[j] ? 0 : 1;
+      v1[j + 1] = [
+        v1[j] + 1,
+        v0[j + 1] + 1,
+        v0[j] + cost,
+      ].reduce((a, b) => a < b ? a : b);
+    }
+    for (var j = 0; j <= t.length; j++) {
+      v0[j] = v1[j];
+    }
+  }
+  return v1[t.length];
+}
+
+double stringSimilarity(String a, String b) {
+  final na = normalizeText(a);
+  final nb = normalizeText(b);
+  final dist = _levenshtein(na, nb);
+  final maxLen = na.length > nb.length ? na.length : nb.length;
+  return maxLen == 0 ? 1.0 : 1.0 - dist / maxLen;
+}
+
+bool isSimilar(String a, String b, {double threshold = 0.8}) {
+  final na = normalizeText(a);
+  final nb = normalizeText(b);
+  if (na.contains(nb) || nb.contains(na)) {
+    return true;
+  }
+  return stringSimilarity(na, nb) >= threshold;
+}

--- a/shop_compare/test/provider_search_test.dart
+++ b/shop_compare/test/provider_search_test.dart
@@ -3,11 +3,11 @@ import 'package:shop_compare/models/product.dart';
 import 'package:shop_compare/providers/shop_provider.dart';
 
 void main() {
-  test('search aggregates results from Yahoo and Rakuten', () async {
+  test('search merges duplicate results', () async {
     final yahooProducts = [
       Product(
         shopName: 'Yahoo',
-        name: 'Y',
+        name: 'テスト商品',
         price: 1,
         shipping: 0,
         shippingName: '',
@@ -15,12 +15,13 @@ void main() {
         eta: '',
         imageUrls: const [],
         itemUrl: '',
+        jan: '123',
       )
     ];
     final rakutenProducts = [
       Product(
         shopName: 'Rakuten',
-        name: 'R',
+        name: 'テスト商品',
         price: 2,
         shipping: 0,
         shippingName: '',
@@ -28,7 +29,19 @@ void main() {
         eta: '',
         imageUrls: const [],
         itemUrl: '',
-      )
+        jan: '123',
+      ),
+      Product(
+        shopName: 'Rakuten',
+        name: '別商品',
+        price: 3,
+        shipping: 0,
+        shippingName: '',
+        deliveryDay: 0,
+        eta: '',
+        imageUrls: const [],
+        itemUrl: '',
+      ),
     ];
 
     final provider = TestShopProvider(
@@ -40,6 +53,9 @@ void main() {
 
     expect(provider.yahooCalled, isTrue);
     expect(provider.rakutenCalled, isTrue);
-    expect(provider.results, equals([...yahooProducts, ...rakutenProducts]));
+    expect(provider.results.length, 2);
+    expect(provider.results.first.shopName, 'Yahoo');
+    expect(provider.results.first.price, 1);
+    expect(provider.results[1].name, '別商品');
   });
 }


### PR DESCRIPTION
## Summary
- add JAN code to Product model
- implement list merge logic and fuzzy matching utilities
- wire mergeProducts into search provider
- verify merging via updated provider test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416df1fd50832aa87430c651d792d5