### PR TITLE
Fix null return and add ndk docs

### DIFF
--- a/shop_compare/README.md
+++ b/shop_compare/README.md
@@ -11,3 +11,13 @@ To fetch dependencies run:
 ```
 flutter pub get
 ```
+
+If you encounter an Android NDK version mismatch error during `flutter run`,
+add the following to `android/app/build.gradle.kts` and ensure the required NDK
+version is installed:
+
+```kotlin
+android {
+    ndkVersion = "27.0.12077973"
+}
+```

--- a/shop_compare/lib/providers/shop_provider.dart
+++ b/shop_compare/lib/providers/shop_provider.dart
@@ -120,7 +120,7 @@ class ShopProvider with ChangeNotifier {
         final data = jsonDecode(res.body) as Map<String, dynamic>;
         final items = data['Items'] as List<dynamic>?;
         if (items == null) return [];
-        return items.map<Product>((e) {
+        return items.map<Product? >((e) {
           final item = e['Item'] as Map<String, dynamic>?;
           if (item == null) {
             return null;


### PR DESCRIPTION
## Summary
- fix nullable return type in ShopProvider
- document required Android NDK version for shop_compare

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68419f410848832aab9b70df19910629